### PR TITLE
Corrected directory name in the setup instructions for eclipse-che.

### DIFF
--- a/support/eclipse-che-setup.md
+++ b/support/eclipse-che-setup.md
@@ -20,7 +20,7 @@ $ source ~/.rvm/scripts/rvm
 
 # fork and clone your fork of blog website and change dir to it
 $ git clone https://github.com/<username>/blog.jboss-outreach.org.git
-$ cd git
+$ cd blog.jboss-outreach.org
 
 $ rvm install "ruby-2.4.2"
 $ rvm use "ruby-2.4.2"


### PR DESCRIPTION
Corrected directory name in the setup instructions for eclipse-che from `cd git` to `cd blog.jboss-outreach.org`

Fixes: https://github.com/JBossOutreach/blog.jboss-outreach.org/issues/125